### PR TITLE
Clean up build, add TypeDoc publish, document

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ cache:
   - $HOME/.m2
 before_deploy:
 - nvm install 6.9.2
-after_deploy:
-- bash src/main/scripts/npm-publish.bash $TRAVIS_TAG cortex
 deploy:
   provider: releases
   api_key:
@@ -36,3 +34,6 @@ deploy:
   on:
     tags: true
     condition: "$TRAVIS_TAG =~ ^[0-9]+\\.[0-9]+\\.[0-9]+$"
+after_deploy:
+- bash src/main/scripts/npm-publish.bash $TRAVIS_TAG cortex
+- bash src/main/scripts/gh-publish.bash $TRAVIS_REPO_SLUG

--- a/README.md
+++ b/README.md
@@ -1,9 +1,64 @@
-# Rug Cortex TypeScript Interface Generator
+# Atomist 'cortex'
 
-[![Build Status](https://travis-ci.org/atomist/rug-cortex-typescript-interface-generator.svg?branch=master)](https://travis-ci.org/atomist/rug-cortex-typescript-interface-generator)
+[![Build Status](https://travis-ci.org/atomist/cortex.svg?branch=master)](https://travis-ci.org/atomist/cortex)
 [![Slack Status](https://join.atomist.com/badge.svg)](https://join.atomist.com)
 
-This project generates the Rug Cortex TypeScript interface sources.
+Dynamically generate the TypeScript NPM module `@atomist/cortex`.
+
+## Developing
+
+Building this project requires downloading the latest version of the
+cortex schema from the model service.  The `install` step of the
+Travis CI build, see [`.travis.yml`][travis-yml], shows how this can
+be done.  This schema is used by the `CortexTypeGeneratorApp`
+in [rug][], which is brought in via a dependency, to generate the
+TypeScript sources during the [Maven][maven] build, see
+the [POM][pom].
+
+```
+$ mvn compile
+```
+
+The generated TypeScript sources can be found under
+`target/.atomist/node_modules/@atomist/cortex`.
+
+[travis-yml]: .travis.yml
+[rug]: https://github.com/atomist/rug
+[maven]: https://maven.apache.org/
+[pom]: pom.xml
+
+If you run the tests, the build will also generated
+the [TypeDoc][typedoc] for the TypeScript module.
+
+```
+$ mvn test
+```
+
+The resulting documentation can be found under `target/typedoc`.
+
+## Releasing
+
+To create a new release of the project, simply push a tag of the form
+`M.N.P` where `M`, `N`, and `P` are integers that form the next
+appropriate [semantic version][semver] for release.  For example:
+
+```
+$ git tag -a 1.2.3
+```
+
+The Travis CI build (see badge at the top of this page) will
+automatically create a GitHub release using the tag name for the
+release and the comment provided on the annotated tag as the contents
+of the release notes.  It will also automatically upload the needed
+artifacts:
+
+-   Node module [`@atomist/cortex`][cortex-npm] to [NPM][npm]
+-   TypeDoc to the gh-pages branch of this repository, which can be
+    viewed at http://cortex.atomist.com/
+
+[semver]: http://semver.org
+[cortex-npm]: https://www.npmjs.com/package/@atomist/cortex
+[npm]: https://www.npmjs.com/
 
 ---
 Created by [Atomist][atomist].

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,6 @@
 	<packaging>jar</packaging>
 	<name>rug-cortex-typescript-interface-generator</name>
 	<description>Generates Rug TypeScript model sources.</description>
-
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
@@ -17,7 +16,6 @@
 		<maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
         <rug.version>0.24.0</rug.version>
 	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>com.atomist</groupId>
@@ -31,7 +29,6 @@
             <scope>test</scope>
         </dependency>
 	</dependencies>
-
 	<repositories>
         <repository>
             <id>public-atomist-release</id>
@@ -47,7 +44,6 @@
             <url>https://maven.atlassian.com/content/repositories/atlassian-public/</url>
         </repository>
     </repositories>
-
 	<distributionManagement>
         <repository>
             <id>public-atomist-release</id>
@@ -55,136 +51,118 @@
             <url>https://atomist.jfrog.io/atomist/libs-release-local</url>
         </repository>
     </distributionManagement>
-
-	<profiles>
-        <profile>
-            <id>npm-release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.github.eirslett</groupId>
-                        <artifactId>frontend-maven-plugin</artifactId>
-                        <version>1.3</version>
-                        <executions>
-                            <execution>
-                                <id>install node and npm</id>
-                                <goals>
-                                    <goal>install-node-and-npm</goal>
-                                </goals>
-                                <configuration>
-                                    <nodeVersion>v7.2.1</nodeVersion>
-                                </configuration>
-                                <phase>generate-sources</phase>
-                            </execution>
-                            <execution>
-                                <id>install typescript and typedoc</id>
-                                <goals>
-                                    <goal>npm</goal>
-                                </goals>
-                                <configuration>
-                                    <!-- Pin versions to things we know are working. TS things tend to break! -->
-                                    <arguments>install --save-dev typescript@2.1.6 @atomist/rug@${rug.version} @types/node@7.0.5 typedoc@0.5.7 gulp@3.9.1 gulp-typedoc@2.0.2  @types/lodash@4.14.56</arguments>
-                                </configuration>
-                                <phase>process-test-resources</phase>
-                            </execution>
-                            <execution>
-                                <id>gulp typedoc cortex</id>
-                                <goals>
-                                    <goal>gulp</goal>
-                                </goals>
-                                <configuration>
-                                    <arguments>typedoc --gulpfile .atomist/node_modules/@atomist/cortex/gulpfile.js</arguments>
-                                </configuration>
-                                <phase>process-test-resources</phase>
-                            </execution>
-                        </executions>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <version>1.3</version>
+                <executions>
+                    <execution>
+                        <id>install node and npm</id>
+                        <goals>
+                            <goal>install-node-and-npm</goal>
+                        </goals>
                         <configuration>
-                            <installDirectory>target/</installDirectory>
-                            <workingDirectory>target/</workingDirectory>
+                            <nodeVersion>v7.2.1</nodeVersion>
                         </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <version>1.8</version>
-                        <executions>
-                            <execution>
-                                <id>compile-typescript</id>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <phase>process-test-resources</phase>
-                                <configuration>
-                                    <target>
-                                        <exec executable="target/node_modules/typescript/bin/tsc" failonerror="true">
-                                            <arg value="-p"/>
-                                            <arg value="target/.atomist/node_modules/@atomist/cortex"/>
-                                        </exec>
-                                    </target>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>cp_cortex_module</id>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <phase>generate-sources</phase>
-                                <configuration>
-                                    <target>
-                                        <copy todir="target/.atomist/node_modules/@atomist/cortex" overwrite="true">
-                                            <fileset dir="src/main/typescript/node_modules/@atomist/cortex"/>
-                                        </copy>
-                                    </target>
-                                </configuration>
-                            </execution>
-                            <!--<execution>-->
-                                <!--<id>mkdir_cortex</id>-->
-                                <!--<goals>-->
-                                    <!--<goal>run</goal>-->
-                                <!--</goals>-->
-                                <!--<phase>generate-sources</phase>-->
-                                <!--<configuration>-->
-                                    <!--<target>-->
-                                        <!--<mkdir dir="target/.atomist/node_modules/@atomist/cortex"/>-->
-                                    <!--</target>-->
-                                <!--</configuration>-->
-                            <!--</execution>-->
-                            <execution>
-                                <id>mkdir_cortex_stub</id>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <phase>generate-sources</phase>
-                                <configuration>
-                                    <target>
-                                        <mkdir dir="target/.atomist/node_modules/@atomist/cortex/stub"/>
-                                    </target>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.5.0</version>
-                        <executions>
-                            <execution>
-                                <id>generate-extended-model</id>
-                                <goals>
-                                    <goal>java</goal>
-                                </goals>
-                                <phase>compile</phase>
-                                <configuration>
-                                    <mainClass>com.atomist.rug.ts.CortexTypeGeneratorApp</mainClass>
-                                    <arguments>
-                                        <argument>target/.atomist/node_modules/@atomist/</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
+                        <phase>generate-sources</phase>
+                    </execution>
+                    <execution>
+                        <id>install typescript and typedoc</id>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Pin versions to things we know are working. TS things tend to break! -->
+                            <arguments>install --save-dev typescript@2.1.6 @atomist/rug@${rug.version} @types/node@7.0.5 typedoc@0.5.7 gulp@3.9.1 gulp-typedoc@2.0.2  @types/lodash@4.14.56</arguments>
+                        </configuration>
+                        <phase>process-test-resources</phase>
+                    </execution>
+                    <execution>
+                        <id>gulp typedoc cortex</id>
+                        <goals>
+                            <goal>gulp</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>typedoc --gulpfile .atomist/node_modules/@atomist/cortex/gulpfile.js</arguments>
+                        </configuration>
+                        <phase>process-test-resources</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <installDirectory>${project.build.directory}</installDirectory>
+                    <workingDirectory>${project.build.directory}</workingDirectory>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>compile-typescript</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>process-test-resources</phase>
+                        <configuration>
+                            <target>
+                                <exec executable="${project.build.directory}/node_modules/typescript/bin/tsc" failonerror="true">
+                                    <arg value="-p"/>
+                                    <arg value="${project.build.directory}/.atomist/node_modules/@atomist/cortex"/>
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>cp-cortex-module</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <target>
+                                <copy todir="${project.build.directory}/.atomist/node_modules/@atomist/cortex" overwrite="true">
+                                    <fileset dir="src/main/typescript/node_modules/@atomist/cortex"/>
+                                </copy>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>mkdir-cortex-stub</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${project.build.directory}/.atomist/node_modules/@atomist/cortex/stub"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.5.0</version>
+                <executions>
+                    <execution>
+                        <id>generate-extended-model</id>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <mainClass>com.atomist.rug.ts.CortexTypeGeneratorApp</mainClass>
+                            <arguments>
+                                <argument>${project.build.directory}/.atomist/node_modules/@atomist</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/scripts/gh-publish.bash
+++ b/src/main/scripts/gh-publish.bash
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Push the HTML docs to the appropriate public repository
+# serving our github pages
+
+set -o pipefail
+declare Pkg=gh-pages-deploy
+declare Version=0.2.0
+
+# print message to stdout
+# usage: msg MESSAGE
+function msg() {
+    echo "$Pkg: $*"
+}
+
+# print message to stderr
+# usage: err MESSAGE
+function err() {
+    msg "$*" 1>&2
+}
+
+# push site to github pages branch, default branch=gh-pages
+# usage: main [REPO_SLUG [BRANCH]]
+function main() {
+    local repo_slug=$1
+    local branch=$2
+
+    if [[ $TRAVIS_PULL_REQUEST && $TRAVIS_PULL_REQUEST != false ]]; then
+        return 0
+    fi
+
+    local repository
+    if [[ $repo_slug ]]; then
+        if [[ ! $GITHUB_TOKEN ]]; then
+            err "repo slug given but GITHUB_TOKEN environment variable is not set"
+            return 1
+        fi
+        repository=https://$GITHUB_TOKEN@github.com/$repo_slug.git
+    else
+        # need origin URL since we later delete .git
+        repository=$(git remote get-url origin)
+        if [[ $? -ne 0 || ! $repository ]]; then
+            err "failed to get URL for origin"
+            return 1
+        fi
+        repo_slug=origin
+    fi
+
+    if [[ ! $branch ]]; then
+        branch=gh-pages
+    fi
+    local refspec=master:$branch
+
+    if ! cd target/typedoc; then
+        err "failed to change to site directory"
+        return 1
+    fi
+    rm -rf .git
+
+    if ! git init; then
+        err "failed to initialize git"
+        return 1
+    fi
+
+    local commit_msg="Local site push"
+    if [[ $TRAVIS == true ]]; then
+        if ! git config user.email "travis-ci@atomist.com"; then
+            err "failed to set git user email"
+            return 1
+        fi
+        if ! git config user.name "Travis CI"; then
+            err "failed to set git user name"
+            return 1
+        fi
+
+        commit_msg="Generated from ${TRAVIS_REPO_SLUG} ${TRAVIS_COMMIT}"
+    fi
+
+    if ! echo cortex.atomist.com > CNAME; then
+        err "failed to create CNAME"
+        return 1
+    fi
+
+    if ! touch .nojekyll; then
+        err "failed to create nojekyll file, continuing"
+    fi
+
+    if ! git add .; then
+        err "failed to add files for commit"
+        return 1
+    fi
+
+    if ! git commit -m "$commit_msg"; then
+        err "failed to commit site files"
+        return 1
+    fi
+
+    if ! git push --force --quiet "$repository" "$refspec" > /dev/null 2>&1; then
+        err "failed to push site"
+        return 1
+    fi
+    msg "published site to $repo_slug"
+}
+
+main "$@" || exit 1
+exit 0

--- a/src/main/scripts/travis-build.bash
+++ b/src/main/scripts/travis-build.bash
@@ -17,7 +17,7 @@ function err() {
 function main() {
     msg "branch is ${TRAVIS_BRANCH}"
 
-    local mvn="mvn --settings .settings.xml -B -V -P npm-release"
+    local mvn="mvn --settings .settings.xml -B -V"
     local project_version
     if [[ $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
         if ! $mvn build-helper:parse-version versions:set -DnewVersion="$TRAVIS_TAG" versions:commit; then

--- a/src/main/typescript/node_modules/@atomist/cortex/gulpfile.js
+++ b/src/main/typescript/node_modules/@atomist/cortex/gulpfile.js
@@ -10,7 +10,7 @@ gulp.task("typedoc", function () {
             module: "commonjs",
             target: "ES5",
             includeDeclarations: true,
-            out: "./typedoc",
+            out: "../../../../typedoc",
             mode: "file",
             // json: "typedoc/rug.json",
             name: "Atomist",


### PR DESCRIPTION
Document build process in README.  Remove npm-publish profile from
POM, just making its contents the default profile.  Use POM properties
where appropriate.  Publish TypeDco to gh-pages branch when
releasing.  Remove TypeDoc from published Node module.